### PR TITLE
209 Improvements to Notes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -451,6 +451,37 @@ span.morethan90 {
 	font-weight: bold;
 }
 
+.editor .meta .notes {
+	display: block;
+	font-weight: normal;
+}
+
+.editor .meta .note {
+	border-top: 1px solid rgba(0, 0, 0, 0.2);
+	padding: 0.2em 0;
+}
+
+.editor .meta .note .date {
+	font-size: 80%;
+	color: #555;
+}
+
+.editor .meta .note-body {
+	font-weight: bold;
+	padding: 0.5em;
+	line-height: 1.2em;
+}
+
+.editor .meta .note-body textarea {
+	width: 100%;
+	box-sizing: border-box;
+}
+
+.editor .meta .note-actions,
+.editor .meta .delete-note {
+	float: right;
+}
+
 /*
  * JavaScript, errors and notices.
  */

--- a/gp-includes/gp.php
+++ b/gp-includes/gp.php
@@ -95,7 +95,7 @@ class GP {
 	public static $glossary_entry;
 
 	/**
-	 * Model for glossary entry.
+	 * Model for notes.
 	 *
 	 * @since 3.0.0
 	 *

--- a/gp-includes/router.php
+++ b/gp-includes/router.php
@@ -125,7 +125,10 @@ class GP_Router {
 			"post:/$set/import-translations" => array( 'GP_Route_Translation', 'import_translations_post' ),
 			"post:/$set/-discard-warning" => array( 'GP_Route_Translation', 'discard_warning' ),
 			"post:/$set/-set-status" => array( 'GP_Route_Translation', 'set_status' ),
-			"post:/$set/-set-note" => array( 'GP_Route_Translation', 'set_note' ),
+			
+			"post:/notes/-new" => array( 'GP_Route_Note', 'new_post' ),
+			"post:/notes/-edit" => array( 'GP_Route_Note', 'edit_post' ),
+			"post:/notes/-delete" => array( 'GP_Route_Note', 'delete_post' ),
 			"/$set/export-translations" => array( 'GP_Route_Translation', 'export_translations_get' ),
 			// Keep this below all URLs ending with a literal string, because it may catch one of them.
 			"get:/$set" => array( 'GP_Route_Translation', 'translations_get' ),

--- a/gp-includes/routes/note.php
+++ b/gp-includes/routes/note.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Routes: GP_Route_Note class
+ *
+ * @package GlotPress
+ * @subpackage Routes
+ * @since 3.0.0
+ */
+
+/**
+ * Class for all note related actions
+ *
+ * @since 3.0.0
+ */
+class GP_Route_Note extends GP_Route_Main {
+
+	/**
+	 * Processes the note set action to set on the translation.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string $html The new row.
+	 */
+	public function new_post() {
+		$status         = gp_post( 'original_id' );
+		$translation_id = gp_post( 'translation_id' );
+		$note = gp_post( 'note' );
+
+		if ( ! $this->verify_nonce( 'new-note-' . $translation_id ) ) {
+			return $this->die_with_error( __( 'An error has occurred. Please try again.', 'glotpress' ), 403 );
+		}
+
+		$translation = GP::$translation->get( gp_post( 'translation_id' ) );
+		$noteObject = GP::$notes->save( $note, $translation );
+
+		$this->render_note($noteObject, $translation);
+	}
+	
+	/**
+	 * Processes the note set action to set on the translation.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return string $html The updated row.
+	 */
+	public function edit_post() {
+		$translation_id = gp_post( 'translation_id' );
+		$note = gp_post( 'note' );
+		$note_id = gp_post( 'note_id' );
+ 
+		if ( ! $this->verify_nonce( 'edit-note-' . $note_id ) ) {
+			return $this->die_with_error( __( 'An error has occurred. Please try again.', 'glotpress' ), 403 );
+		}
+
+		$translation = GP::$translation->get( $translation_id );
+		$noteObject = GP::$notes->edit( $note_id, $note, $translation );
+
+		$this->render_note( $noteObject, $translation );
+	}
+	
+	/**
+	 * Processes the note set action to set on the translation.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	public function delete_post() {
+		
+		$note_id = gp_post( 'note_id' );
+
+		if ( ! $this->verify_nonce( 'delete-note-' . $note_id ) ) {
+			return $this->die_with_error( __( 'An error has occurred. Please try again.', 'glotpress' ), 403 );
+		}
+		GP::$notes->delete_all( array('id' => $note_id) );
+
+		return true;
+	}
+	
+	/**
+	 * 
+	 * @param object $note
+	 * @param object $translation
+	 */
+	private function render_note( $note, $translation )
+	{
+		require_once GP_TMPL_PATH . 'helper-functions.php';
+		$can_approve = $this->can( 'approve', 'translation-set', $translation->translation_set_id );
+		render_note($note, $can_approve);
+	}
+}

--- a/gp-includes/routes/translation.php
+++ b/gp-includes/routes/translation.php
@@ -221,7 +221,9 @@ class GP_Route_Translation extends GP_Route_Main {
 		$set_priority_url = gp_url( '/originals/%original-id%/set_priority');
 		$discard_warning_url = gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug, '-discard-warning' ) );
 		$set_status_url = gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug, '-set-status' ) );
-		$set_note_url = gp_url_project( $project, gp_url_join( $locale->slug, $translation_set->slug, '-set-note' ) );
+		$new_note_url = gp_url( '/notes/-new' );
+		$edit_note_url = gp_url( '/notes/-edit' );
+		$delete_note_url = gp_url( '/notes/-delete' );
 		$bulk_action = gp_url_join( $url, '-bulk' );
 
 		// Add action to use different font for translations
@@ -548,32 +550,6 @@ class GP_Route_Translation extends GP_Route_Main {
 		}
 
 		return $this->edit_single_translation( $project_path, $locale_slug, $translation_set_slug, array( $this, 'set_status_edit_function' ) );
-	}
-
-	/**
-	 * Processes the note set action to seton the translation.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param string $project_path          The project path.
-	 * @param string $locale_slug           The locale slug.
-	 * @param string $translation_set_slug  The translation set slug.
-	 *
-	 * @return string $html The new row.
-	 */
-	public function set_note( $project_path, $locale_slug, $translation_set_slug ) {
-		$status         = gp_post( 'original_id' );
-		$translation_id = gp_post( 'translation_id' );
-		$note = gp_post( 'note' );
-
-		if ( ! $this->verify_nonce( 'add-note_' . $translation_id ) && ! $this->verify_nonce( 'update-notes_' . $translation_id ) ) {
-			return $this->die_with_error( __( 'An error has occurred. Please try again.', 'glotpress' ), 403 );
-		}
-
-		$translation = GP::$translation->get( gp_post( 'translation_id' ) );
-		GP::$notes->save( $note, $translation );
-
-		return $this->edit_single_translation( $project_path, $locale_slug, $translation_set_slug, '' );
 	}
 
 	private function edit_single_translation( $project_path, $locale_slug, $translation_set_slug, $edit_function ) {

--- a/gp-includes/schema.php
+++ b/gp-includes/schema.php
@@ -104,6 +104,7 @@ function gp_schema_get() {
 		note text NOT NULL,
 		user_id bigint(20) DEFAULT NULL,
 		date_added datetime DEFAULT NULL,
+		date_modified datetime DEFAULT NULL,
 		PRIMARY KEY  (id),
 		KEY original_id (original_id),
 		KEY user_id (user_id),

--- a/gp-includes/things/note.php
+++ b/gp-includes/things/note.php
@@ -33,6 +33,7 @@ class GP_Note extends GP_Thing {
 		'note',
 		'user_id',
 		'date_added',
+		'date_modified',
 	);
 
 	/**
@@ -52,8 +53,9 @@ class GP_Note extends GP_Thing {
 	 *
 	 * @var array $non_updatable_attributes
 	 */
-	public $non_updatable_attributes = array( 'id', 'original_id', 'translation_set_id' );
-
+	public $non_updatable_attributes = array( 'id' );
+	
+	public $default_order = 'ORDER BY date_added DESC';
 
 	/**
 	 * Save the note
@@ -61,7 +63,7 @@ class GP_Note extends GP_Thing {
 	 * @since 3.0.0
 	 *
 	 * @param string $note    The new note.
-	 * @param string $translation The translation object.
+	 * @param object $translation The translation object.
 	 *
 	 * @return object The output of the query.
 	 */
@@ -74,60 +76,48 @@ class GP_Note extends GP_Thing {
 		) ) {
 			return false;
 		}
-		if ( GP::$permission->current_user_can( 'admin', 'notes', $translation->id ) ) {
-			$saved_note = esc_html( gp_post( 'update_note' ) );
-		}
-		if ( empty( $saved_note ) ) {
-			$saved_note = $this->get( $translation );
-			$saved_note = $saved_note['note'];
-		}
-
-		$current_date = $translation->now_in_mysql_format();
-		$current_user = wp_get_current_user();
-		$current_user = $current_user->data->display_name;
-
-		if ( ! empty( $saved_note ) ) {
-			if ( ! empty( $note ) ) {
-					$note = $current_user . ' @ ' . $current_date . ' added:' . "\n" . $note . "\n" . $saved_note;
-			} else {
-					$note = $saved_note;
-			}
-			return $translation->query(
-				"UPDATE $wpdb->gp_notes SET note = '%s', user_id = '%s', date_added = '%s' WHERE (original_id = '%s' AND translation_set_id = '%s')", $note, get_current_user_id(), $current_date, $translation->original_id, $translation->translation_set_id
-			);
-		} else {
-			if ( ! empty( $note ) ) {
-				$note = $current_user . ' @ ' . $current_date . ' added:' . "\n" . $note;
-				return $translation->query(
-					"
-					INSERT INTO $wpdb->gp_notes (
-					original_id, translation_set_id, note, user_id, date_added
-					)
-					VALUES (%s, %s, %s, %s, %s)", $translation->original_id, $translation->translation_set_id, $note, get_current_user_id(), $current_date
-				);
-			}
-		}
+		
+		$note = trim($note);
+		
+		return $this->create(
+			array(
+				'original_id' => $translation->original_id,
+				'translation_set_id' => $translation->translation_set_id,
+				'note' => $note,
+				'user_id' => get_current_user_id(), 
+			)
+		);
 	}
-
+	
+	public function edit($note_id, $note, $translation)
+	{
+		if ( false === GP::$permission->current_user_can( 'admin', 'notes', $translation->id ) ) {
+			return false;
+		}
+		
+		$this->update(array('note' => $note), array('id' => $note_id));
+		
+		return $this->get($note_id);
+	}
 
 	/**
 	 * Retrieves the note for this entry.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string $entry The translation entry.
+	 * @param object $entry The translation entry.
 	 *
-	 * @return string The note.
+	 * @return array notes
 	 */
-	function get( $entry ) {
-		global $wpdb;
-
-		$result = $wpdb->get_results( sprintf( "SELECT * FROM $wpdb->gp_notes WHERE (original_id = '%s' AND translation_set_id = '%s') LIMIT 1", $entry->original_id, $entry->translation_set_id ), ARRAY_A );
-		if ( count( $result ) > 0 ) {
-			return $result[0];
-		}
-		return array(
-			'note' => '',
+	function get_by_entry( $entry, $order = null ) {
+		return $this->many( 
+			$this->select_all_from_conditions_and_order( 
+				array(
+					'original_id' => $entry->original_id,
+					'translation_set_id' => $entry->translation_set_id,
+				), 
+				$order 
+			) 
 		);
 	}
 }

--- a/gp-includes/things/translation.php
+++ b/gp-includes/things/translation.php
@@ -635,21 +635,6 @@ class GP_Translation extends GP_Thing {
 		return $updated;
 	}
 
-	/**
-	 * Save the note
-	 *
-	 * @since 3.0.0
-	 *
-	 * @return string The content of the note.
-	 */
-	public function save_note() {
-		$note = esc_html( gp_post( 'note' ) );
-
-		GP::$notes->save( $note, $this );
-
-		return $note;
-	}
-
 	public function translations() {
 		$translations = array();
 

--- a/gp-settings.php
+++ b/gp-settings.php
@@ -105,6 +105,7 @@ require_once GP_PATH . GP_INC . 'routes/translation.php';
 require_once GP_PATH . GP_INC . 'routes/glossary.php';
 require_once GP_PATH . GP_INC . 'routes/glossary-entry.php';
 require_once GP_PATH . GP_INC . 'routes/locale.php';
+require_once GP_PATH . GP_INC . 'routes/note.php';
 
 
 GP::$translation_warnings = new GP_Translation_Warnings();

--- a/gp-templates/translation-row.php
+++ b/gp-templates/translation-row.php
@@ -240,7 +240,9 @@ if ( is_object( $glossary ) ) {
 					<dd><?php gp_link_user( $t->user_last_modified ); ?></dd>
 				</dl>
 			<?php endif; ?>
-						<?php notes( $t, array( $can_edit, $can_approve_translation ) ); ?>
+			<?php 
+			render_notes( $t, array( $can_edit, $can_approve_translation ) ); 
+			?>
 			<?php references( $project, $t ); ?>
 
 			<dl>

--- a/gp-templates/translations.php
+++ b/gp-templates/translations.php
@@ -15,7 +15,7 @@ wp_localize_script(
 );
 
 // localizer adds var in front of the variable name, so we can't use $gp.editor.options
-$editor_options = compact( 'can_approve', 'can_write', 'url', 'discard_warning_url', 'set_priority_url', 'set_status_url', 'set_note_url' );
+$editor_options = compact( 'can_approve', 'can_write', 'url', 'discard_warning_url', 'set_priority_url', 'set_status_url', 'new_note_url', 'edit_note_url', 'delete_note_url' );
 
 wp_localize_script( 'gp-editor', '$gp_editor_options', $editor_options );
 


### PR DESCRIPTION
Normalize notes to use one row per note to allow more flexabilty is presentation

Each note row body only contains the contents of the note.
Which makes it possible to change the presentation without updating all the rows is the database.
Each note can be deleted and edited individually.
Also displays the date in more human readable format.